### PR TITLE
feat: add methods for most and fewest tackles along with tests

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -322,4 +322,31 @@ class StatTracker
     win_percentages.max_by { |coach, percentage|
       percentage }.first
   end
+
+  def tackles(season)
+    team_records = {}
+    season_year = season[0..3]
+
+    @game_teams.each do |game|
+      next unless game.game_id[0..3] == season_year
+  
+    team_id = game.team_id
+    tackles = game.tackles
+    #require "pry"; binding.pry
+    team_records[team_id] ||= {tackles: 0}
+    team_records[team_id][:tackles] += tackles
+    end
+  team_records
+end
+
+def most_tackles(season)
+  tackles_tracker = tackles(season)
+  find_team_name(tackles_tracker.max[0])
+end
+
+def fewest_tackles(season)
+  tackles_tracker = tackles(season)
+  find_team_name(tackles_tracker.min[0])
+end
+
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -117,4 +117,17 @@ RSpec.describe StatTracker do
         expect(@stat_tracker.worst_coach("20122013")).to eq("John Tortorella")
       end
     end
+
+    describe "#most_tackles" do
+      it "can return the team with the most total tackles based on season" do
+        expect(@stat_tracker.most_tackles("2012030221")).to eq("FC Dallas")
+      end
+    end
+
+    describe "#fewest_tackles" do
+    it "can return the team with the fewest total tackles based on season" do
+      expect(@stat_tracker.fewest_tackles("2012030221")).to eq("Atlanta United")
+    end
+  end
+
   end


### PR DESCRIPTION
Add the tackles method along with most and fewest tackles.

To calculate this I based this off of just total tackles (I did not do tackles per game average).

I also added tests