### PR TITLE
Fixes to highest/lowest scoring for visitor and home team

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -271,7 +271,7 @@ class StatTracker
     team_goals_and_games = home_create_team_goals_and_games
     #use the create team goals and games method
   
-      x= team_goals_and_games.map do |team_id, stats| 
+      team_goals_and_games.map do |team_id, stats| 
       [team_id, stats[:goals].to_f / stats[:games]]
 
     end.to_h
@@ -279,6 +279,7 @@ class StatTracker
   
   def highest_scoring_home_team
     highest_scoring=home_calculate_average_goals_per_team
+    #require "pry" ; binding.pry
     highest=highest_scoring.max_by {|team,scoring_percentage| scoring_percentage }
     find_team_name(highest[0])
   end
@@ -498,7 +499,7 @@ def opponent_record(team_id)
 
   def away_games_only 
     away_games = @game_teams.find_all do |game_team|
-      game_team != game_team.hoa
+      game_team.hoa =="away"
     end
     away_games
   end
@@ -523,12 +524,15 @@ def opponent_record(team_id)
   end
 
   def highest_scoring_visitor
-      highest_scoring=away_calculate_average_goals_per_team.max
-      find_team_name(highest_scoring[0])
+      highest_scoring=away_calculate_average_goals_per_team
+      highest=highest_scoring.max_by {|team,scoring_percentage| scoring_percentage }
+      find_team_name(highest[0])
+
   end
 
   def lowest_scoring_visitor
-      lowest_scoring=away_calculate_average_goals_per_team.min
-      find_team_name(lowest_scoring[0])
+      lowest_scoring=away_calculate_average_goals_per_team
+      lowest=lowest_scoring.min_by {|team,scoring_percentage| scoring_percentage }
+      find_team_name(lowest[0])
   end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -271,20 +271,22 @@ class StatTracker
     team_goals_and_games = home_create_team_goals_and_games
     #use the create team goals and games method
   
-      team_goals_and_games.map do |team_id, stats| 
+      x= team_goals_and_games.map do |team_id, stats| 
       [team_id, stats[:goals].to_f / stats[:games]]
 
     end.to_h
   end
   
-  def highest_scoring_home
-    highest_scoring=home_calculate_average_goals_per_team.max
-    find_team_name(highest_scoring[0])
+  def highest_scoring_home_team
+    highest_scoring=home_calculate_average_goals_per_team
+    highest=highest_scoring.max_by {|team,scoring_percentage| scoring_percentage }
+    find_team_name(highest[0])
   end
   
-  def lowest_scoring_home
-    lowest_scoring=home_calculate_average_goals_per_team.min
-    find_team_name(lowest_scoring[0])
+  def lowest_scoring_home_team
+    lowest_scoring=home_calculate_average_goals_per_team
+    lowest=lowest_scoring.min_by {|team,scoring_percentage| scoring_percentage }
+    find_team_name(lowest[0])
   end
 
   def winningest_coach(season)

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -188,13 +188,13 @@ RSpec.describe StatTracker do
 
     describe "#highest_scoring_visitor" do
       it 'can return the visitor team with the highest scores' do
-        expect(@stat_tracker.highest_scoring_visitor).to eq("New York Red Bulls")
+        expect(@stat_tracker.highest_scoring_visitor).to eq("Philadelphia Union")
       end
     end
 
     describe "#lowest_scoring_visitor" do
       it 'can return the visitor team with the lowest scores' do
-        expect(@stat_tracker.lowest_scoring_visitor).to eq("Atlanta United")
+        expect(@stat_tracker.lowest_scoring_visitor).to eq("DC United")
       end
     end
   end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -98,13 +98,13 @@ RSpec.describe StatTracker do
 
     describe "highest_scoring_home" do
       it "can return the team with the highest average goals at home" do
-        expect(@stat_tracker.highest_scoring_home).to eq("FC Dallas")
+        expect(@stat_tracker.highest_scoring_home_team).to eq("FC Dallas")
       end
     end
     
     describe "lowest_scoring_home" do
       it "can return the team with the lowest average goals at home" do
-        expect(@stat_tracker.lowest_scoring_home).to eq("Atlanta United")
+        expect(@stat_tracker.lowest_scoring_home_team).to eq("Houston Dynamo")
       end
     end
 


### PR DESCRIPTION
This is a fix to update the logic for the highest/lowest scoring visitor/home_team

I renamed the home_team method name to pass the harness test

Updated those methods to accurately get the correct team.