### PR TITLE
feat: added head_to_head method and tests

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -384,14 +384,14 @@ def opponent_record(team_id)
       team_home = game.home_team_id
       team_away = game.away_team_id
       if game.away_team_id ==team_id
-         opponent_records[team_home] ||= {wins_against: 0, loss_against: 0, total_games:0}
+         opponent_records[team_home] ||= {wins_against: 0, total_games:0}
          opponent_records[team_home][:total_games] +=1
-         opponent_records[team_home][:wins_against] += 1 if game.away_goals < game.home_goals
+         opponent_records[team_home][:wins_against] += 1 if game.away_goals > game.home_goals
 
       elsif game.home_team_id ==team_id
-        opponent_records[team_away] ||= {wins_against: 0, loss_against: 0, total_games:0}
+        opponent_records[team_away] ||= {wins_against: 0, total_games:0}
         opponent_records[team_away][:total_games] +=1
-        opponent_records[team_away][:wins_against] += 1 if game.away_goals > game.home_goals
+        opponent_records[team_away][:wins_against] += 1 if game.away_goals < game.home_goals
       end
     end
     win_percentages = {}
@@ -403,7 +403,7 @@ def opponent_record(team_id)
 
   def favorite_opponent(team_id)
     records = opponent_record(team_id)
-    favorite_opponent = records.min_by do |team, percentage|
+    favorite_opponent = records.max_by do |team, percentage|
       percentage
     end
     find_team_name(favorite_opponent[0])
@@ -411,7 +411,7 @@ def opponent_record(team_id)
 
   def rival(team_id)
     records=opponent_record(team_id)
-    rival = records.max_by do |team, percentage|
+    rival = records.min_by do |team, percentage|
       percentage
     end
     find_team_name(rival[0])
@@ -534,5 +534,14 @@ def opponent_record(team_id)
       lowest_scoring=away_calculate_average_goals_per_team
       lowest=lowest_scoring.min_by {|team,scoring_percentage| scoring_percentage }
       find_team_name(lowest[0])
+  end
+
+  def head_to_head(team_id)
+    record = opponent_record(team_id)
+    head_to_head_hash ={}
+    record.each do |team_id,win_percentage|
+      head_to_head_hash[find_team_name(team_id)] = win_percentage
+    end
+    head_to_head_hash
   end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -197,4 +197,11 @@ RSpec.describe StatTracker do
         expect(@stat_tracker.lowest_scoring_visitor).to eq("DC United")
       end
     end
+
+    describe "head_to_head" do
+      it 'can give win percentages for a team against all other teams' do
+        hash={"Chicago Fire"=>0.0, "Orlando Pride"=>0.0, "Seattle Sounders FC"=>1.0}
+        expect(@stat_tracker.head_to_head("8")).to eq(hash)
+      end
+    end
   end


### PR DESCRIPTION
This includes the head_to_head method and tests.

For this test, I reused the opponent_record method. Within that method I switched the logic, previously it was tracking the wins the other team had over the main team provided in the parameter. Now it tracks the wins of the team id provided in the parameter. The favorite_opponent and rival methods were switched accordingly And those tests pass as expected.