### PR TITLE
Fix bugs

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -337,7 +337,7 @@ class StatTracker
 
       coach_records[coach] ||= { wins: 0, total_games: 0 }
       coach_records[coach][:total_games] += 1
-      coach_records[coach][:wins] += 1 if result == "LOSS"
+      coach_records[coach][:wins] += 1 if result == "WIN"
 
       end
       return nil if coach_records.empty?
@@ -348,7 +348,7 @@ class StatTracker
       win_percentages[coach] = record[:wins].to_f / record[:total_games]
     end
 
-    win_percentages.max_by { |coach, percentage|
+    win_percentages.min_by { |coach, percentage|
       percentage }.first
   end
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -480,12 +480,12 @@ def opponent_record(team_id)
       if team.team_id == team_id
     
       team_info = {
-          team_id: team.team_id, 
-          franchise_id: team.franchiseid, 
-          team_name: team.teamname, 
-          abbreviation: team.abbreviation, 
-          link: team.link
-      }
+          "team_id" => team.team_id, 
+          "franchise_id" => team.franchiseid, 
+          "team_name" => team.teamname, 
+          "abbreviation" => team.abbreviation, 
+          "link" => team.link
+        }
         break
       end
     end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -184,7 +184,7 @@ class StatTracker
   end
 
   def average_goals_per_game
-    total_goals.sum / @games.size.to_f
+    (total_goals.sum / @games.size.to_f).round(2)
   end
 
   def create_season_goals_and_games

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -181,19 +181,19 @@ end
       team_id, franchise_id, team_name, abbreviation, and link" do
         
         expect(@stat_tracker.team_info("53")).to eq({
-          :team_id => "53", 
-          :franchise_id => "28", 
-          :team_name => "Columbus Crew SC",
-          :abbreviation => "CCS",
-          :link => "/api/v1/teams/53"
+          "team_id" => "53", 
+          "franchise_id" => "28", 
+          "team_name" => "Columbus Crew SC",
+          "abbreviation" => "CCS",
+          "link" => "/api/v1/teams/53"
           })
 
       expect(@stat_tracker.team_info("1")).to eq({
-         :team_id => "1", 
-         :franchise_id => "23", 
-         :team_name => "Atlanta United",
-         :abbreviation => "ATL",
-         :link => "/api/v1/teams/1"
+         "team_id" => "1", 
+         "franchise_id" => "23", 
+         "team_name" => "Atlanta United",
+         "abbreviation" => "ATL",
+         "link" => "/api/v1/teams/1"
           })
       end
     end


### PR DESCRIPTION
I changed three methods so that they would pass the spec_harness
1. team_info because the key in the hash needed to be a string instead of a symbol
2. worst_coach because I was using "LOSS" and finding the percentage max by, but the spec harness used "WIN" and found the percentage min by. This was just a slight tweak that when I had run it on our dummy data in both of these ways, it did not impact the result, but it did in spec_harness
3. average_goals_per_game because it needed to be rounded to 2