### PR TITLE
feat: add methods for biggest blowout and worst loss with helper methods and tests

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -612,4 +612,74 @@ def opponent_record(team_id)
     end
     worst_season
   end
+
+  def calculate_team_wins(team_id)
+    team_wins = []
+
+    @game_teams.each do |game_team|
+      if game_team.team_id.to_s == team_id.to_s && game_team.result == 'WIN'
+        team_wins << game_team.game_id
+      end
+    end
+    team_wins
+  end
+
+  def calculate_team_losses(team_id)
+    team_losses = []
+
+    @game_teams.each do |game_team|
+      if game_team.team_id.to_s == team_id.to_s && game_team.result == 'LOSS'
+        team_losses << game_team.game_id
+      end
+    end
+    team_losses
+  end
+
+  def calculate_winning_points_differences(team_id)
+    team_wins = calculate_team_wins(team_id)
+    winning_points_differences = {}
+
+    @games.each do |game|
+      next unless team_wins.include?(game.game_id.to_s)
+
+      points_difference = if game.away_team_id.to_s == team_id.to_s
+        game.away_goals - game.home_goals
+      else
+        game.home_goals - game.away_goals
+      end
+
+      winning_points_differences[game.game_id] = points_difference
+    end
+    winning_points_differences
+  end
+
+  def biggest_team_blowout(team_id)
+    winning_points_differences = calculate_winning_points_differences(team_id)
+    biggest_team_blowout = winning_points_differences.values.max
+    biggest_team_blowout
+  end
+
+  def calculate_losing_points_differences(team_id)
+    team_losses = calculate_team_losses(team_id)
+    losing_points_differences = {}
+
+    @games.each do |game|
+      next unless team_losses.include?(game.game_id.to_s)
+
+      points_difference = if game.away_team_id.to_s == team_id.to_s
+        game.home_goals - game.away_goals
+      else
+        game.away_goals - game.home_goals
+      end
+
+      losing_points_differences[game.game_id] = points_difference
+    end
+    losing_points_differences
+  end
+
+  def worst_loss(team_id)
+    losing_points_differences = calculate_losing_points_differences(team_id)
+    worst_loss = losing_points_differences.values.max
+    worst_loss
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -223,4 +223,23 @@ end
       expect(@stat_tracker.best_season(3)).to eq(nil)
       expect(@stat_tracker.worst_season("6")).to eq "20122013"
     end
+
+    it 'identifies team wins and losses' do
+      expect(@stat_tracker.calculate_team_wins(6)).to be_a(Array)
+      expect(@stat_tracker.calculate_team_wins(6).length).to eq(3)
+      expect(@stat_tracker.calculate_team_losses(6).length).to eq(0)
+      expect(@stat_tracker.calculate_team_losses(3).length).to eq(3)
+    end
+
+    it 'calculates points differences' do
+      expect(@stat_tracker.calculate_winning_points_differences(6)).to be_a(Hash)
+    end
+
+    it 'identifies a teams biggest blowout' do
+      expect(@stat_tracker.biggest_team_blowout(6)).to eq(1)
+    end
+
+    it 'identifies a teams worst loss' do
+      expect(@stat_tracker.worst_loss(3)).to eq(1)
+    end
   end


### PR DESCRIPTION
This PR adds methods for biggest team blowout and worst loss, as well as related helper methods and tests. All tests are passing both spec file and spec harness.

Summary of changes:
1. Add methods for biggest team blowout and worst loss, defined by the biggest points difference between the winning and losing team
2. Add helper methods, including calculate team wins, calculate team losses, calculate winning points difference, and calculate losing points difference
3. Add related tests