### PR TITLE
moved methods to correct stat module

### DIFF
--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -2,6 +2,6 @@
   "RSpec": {
     "coverage": {
     },
-    "timestamp": 1727016968
+    "timestamp": 1727022566
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2024-09-22T09:56:08-05:00">2024-09-22T09:56:08-05:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2024-09-22T11:29:26-05:00">2024-09-22T11:29:26-05:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">

--- a/lib/game_stat.rb
+++ b/lib/game_stat.rb
@@ -24,8 +24,8 @@ module GameStat
         end
     end
 
-    total_games = games.size
-    percentage = (home_wins.to_f / total_games * 100).round(2)
+    total_games = games.count
+    percentage = (home_wins.to_f / total_games).round(2)
     end
 
     def percentage_visitor_wins
@@ -36,8 +36,8 @@ module GameStat
         end
     end
 
-    total_games = games.size
-    percentage = (visitor_wins.to_f / total_games * 100).round(2)
+    total_games = games.count
+    percentage = (visitor_wins.to_f / total_games).round(2)
     end
 
     def percentage_ties
@@ -48,8 +48,8 @@ module GameStat
         end
     end
 
-    total_games = games.size
-    percentage = (ties.to_f / total_games * 100).round(2)
+    total_games = games.count
+    percentage = (ties.to_f / total_games).round(2)
     end
 
     def home_games_only #for highest/lowest scoring at home

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -82,32 +82,4 @@ class StatTracker
           row[:takeaways].to_i)
       end
     end
-
-    def most_goals_scored(team_id)
-      team_games = @games.select { |game| game.home_team_id == team_id || game.away_team_id == team_id }
-    
-      max_goals = team_games.map do |game|
-        if game.home_team_id == team_id
-          game.home_goals
-        else
-          game.away_goals
-        end
-      end.max
-    
-        max_goals
-      end
-    
-    def fewest_goals_scored(team_id)
-      team_games = @games.select { |game| game.home_team_id == team_id || game.away_team_id == team_id }
-    
-      min_goals = team_games.map do |game|
-        if game.home_team_id == team_id
-          game.home_goals
-        else
-          game.away_goals
-        end
-      end.min
-    
-        min_goals
-      end
 end

--- a/lib/team_stat.rb
+++ b/lib/team_stat.rb
@@ -189,6 +189,32 @@ module TeamStat
         head_to_head_hash
     end
 
+    def most_goals_scored(team_id)
+        team_games = @games.select { |game| game.home_team_id == team_id || game.away_team_id == team_id }
+      
+        max_goals = team_games.map do |game|
+          if game.home_team_id == team_id
+            game.home_goals
+          else
+            game.away_goals
+          end
+        end.max
+          max_goals
+        end
+
+      def fewest_goals_scored(team_id)
+        team_games = @games.select { |game| game.home_team_id == team_id || game.away_team_id == team_id }
+      
+        min_goals = team_games.map do |game|
+          if game.home_team_id == team_id
+            game.home_goals
+          else
+            game.away_goals
+          end
+        end.min
+          min_goals
+        end  
+
     def calculate_season_summary(team_id)
         season_stats ={}
         @games.each do |game|

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -78,19 +78,19 @@ RSpec.describe StatTracker do
     end
     describe "percentage_home_wins" do
     it 'can return the percentage of home wins' do
-      expect(@stat_tracker.percentage_home_wins).to eq(40.0)
+      expect(@stat_tracker.percentage_home_wins).to eq(0.44)
     end
   end
 
     describe "percentage_visitor_wins" do
     it 'can return the percentage of away wins' do
-      expect(@stat_tracker.percentage_visitor_wins).to eq(36.0)
+      expect(@stat_tracker.percentage_visitor_wins).to eq(0.36)
     end
   end
 
     describe "percentage_ties" do
     it 'can return the percentage of ties' do
-      expect(@stat_tracker.percentage_ties).to eq(24.0)
+      expect(@stat_tracker.percentage_ties).to eq(0.24)
     end
   end
 


### PR DESCRIPTION
In this pull request, I moved the fewest and most goals scored to the team_stat file.

Working on tests for 
Percentage_visitor_wins
Percentage_home_wins
Percentage_ties

One test currently failing - this is so I will know once the method is functioning properly, it has what the outcome should be to be expected. Will update and create another PR once this is fixed. 